### PR TITLE
feat(model): Add optional memoization to datasets during model training.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,9 @@ jobs:
       - name: Install Poetry
         run: |
           pwd
+          ls -la
           cat .github/workflows/constraints.txt
+          cat ./.github/workflows/constraints.txt
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
           poetry --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,16 +53,14 @@ jobs:
 
       - name: Install Poetry
         run: |
-          ls -la .github/workflows/
-          cat .github/workflows/constraints.txt
           echo "Installing poetry with pipx"
           pipx install --pip-args="--constraint ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Install Nox
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt nox
-          pipx inject --pip-args=--constraint=.github/workflows/constraints.txt nox nox-poetry
+          pipx install --pip-args="--constraint ${{ github.workspace }}/.github/workflows/constraints.txt" nox
+          pipx inject --pip-args="--constraint ${{ github.workspace }}/.github/workflows/constraints.txt" nox nox-poetry
           nox --version
 
       - name: Compute pre-commit cache key

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install Poetry
         run: |
+          pwd
+          cat .github/workflows/constraints.txt
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
           poetry --version
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,8 @@ jobs:
         run: |
           ls -la .github/workflows/
           cat .github/workflows/constraints.txt
-          cat .github/workflows/constraints.txt
           echo "Installing poetry with pipx"
-          pipx install --pip-args="--constraint .github/workflows/constraints.txt" poetry
+          pipx install --pip-args="--constraint ${{ github.workspace }}/.github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Install Nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           ls -la
           cat .github/workflows/constraints.txt
           cat ./.github/workflows/constraints.txt
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pipx install --pip-args=--constraint=./.github/workflows/constraints.txt poetry
           poetry --version
 
       - name: Install Nox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pwd
-          ls -la
+          ls -la .github/workflows/
           cat .github/workflows/constraints.txt
-          cat ./.github/workflows/constraints.txt
-          pipx install --pip-args=--constraint=./.github/workflows/constraints.txt poetry
+          cat .github/workflows/constraints.txt
+          echo "Installing poetry with pipx"
+          pipx install --pip-args="--constraint .github/workflows/constraints.txt" poetry
           poetry --version
 
       - name: Install Nox

--- a/mleko/dataset/data_schema.py
+++ b/mleko/dataset/data_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 from typing import Literal
 
+from mleko.cache.fingerprinters.dict_fingerprinter import DictFingerprinter
 from mleko.utils.custom_logger import CustomLogger
 
 
@@ -52,6 +53,32 @@ class DataSchema:
             "datetime": sorted(list(datetime)),
             "timedelta": sorted(list(timedelta)),
         }
+
+    def __eq__(self, other: DataSchema) -> bool:
+        """Check if two DataSchema objects are equal.
+
+        Args:
+            other: DataSchema object to compare with.
+
+        Returns:
+            True if the two DataSchema objects are equal, False otherwise.
+        """
+        return isinstance(other, DataSchema) and DictFingerprinter().fingerprint(
+            self.to_dict()
+        ) == DictFingerprinter().fingerprint(other.to_dict())
+
+    def __hash__(self) -> int:
+        """Get the hash of the DataSchema.
+
+        Warning:
+            This method is not intended to be used for stable hashing across runs. Please
+            refer to the `DictFingerprinter` class in the `mleko.utils.fingerprinter` module
+            for stable hashing of the DataSchema.
+
+        Returns:
+            Hash of the DataSchema.
+        """
+        return hash(DictFingerprinter().fingerprint(self.to_dict()))
 
     def __repr__(self) -> str:
         """Get the string representation of DataSchema.

--- a/mleko/dataset/data_schema.py
+++ b/mleko/dataset/data_schema.py
@@ -54,11 +54,11 @@ class DataSchema:
             "timedelta": sorted(list(timedelta)),
         }
 
-    def __eq__(self, other: DataSchema) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Check if two DataSchema objects are equal.
 
         Args:
-            other: DataSchema object to compare with.
+            other: Object to compare with.
 
         Returns:
             True if the two DataSchema objects are equal, False otherwise.

--- a/mleko/dataset/transform/label_encoder_transformer.py
+++ b/mleko/dataset/transform/label_encoder_transformer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import re
 from pathlib import Path
 from typing import Hashable
@@ -10,6 +9,7 @@ from typing import Hashable
 import vaex
 import vaex.array_types
 
+from mleko.cache.fingerprinters import DictFingerprinter
 from mleko.dataset.data_schema import DataSchema
 from mleko.utils.custom_logger import CustomLogger
 from mleko.utils.decorators import auto_repr
@@ -195,7 +195,7 @@ class LabelEncoderTransformer(BaseTransformer):
             super()._fingerprint(),
             self._allow_unseen,
             self._encode_null,
-            json.dumps(self._label_dict, sort_keys=True) if self._label_dict is not None else None,
+            DictFingerprinter().fingerprint(self._label_dict),
         )
 
     def _fit_using_label_dict(self, feature: str, observed_labels: list[str]) -> bool:

--- a/mleko/model/base_model.py
+++ b/mleko/model/base_model.py
@@ -273,7 +273,7 @@ class BaseModel(LRUCacheMixin, ABC):
 
     def clear_load_dataset_cache(self) -> None:
         """Clears the cache for the `_memoized_load_dataset` method."""
-        self._memoized_load_dataset.cache_clear()
+        self._memoized_load_dataset.cache_clear()  # type: ignore
 
     def _fit_transform(
         self,

--- a/mleko/model/base_model.py
+++ b/mleko/model/base_model.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Hashable, Union
 
+import pandas as pd
 import vaex
 
 from mleko.cache.fingerprinters import DictFingerprinter, VaexFingerprinter
@@ -13,6 +15,7 @@ from mleko.cache.handlers import JOBLIB_CACHE_HANDLER, VAEX_DATAFRAME_CACHE_HAND
 from mleko.cache.lru_cache_mixin import LRUCacheMixin
 from mleko.dataset.data_schema import DataSchema
 from mleko.utils.custom_logger import CustomLogger
+from mleko.utils.vaex_helpers import HashableVaexDataFrame, get_columns
 
 
 logger = CustomLogger()
@@ -45,6 +48,7 @@ class BaseModel(LRUCacheMixin, ABC):
         self,
         features: list[str] | tuple[str, ...] | None,
         ignore_features: list[str] | tuple[str, ...] | None,
+        memoized_dataset_cache_size: int | None,
         cache_directory: str | Path,
         cache_size: int,
     ) -> None:
@@ -54,11 +58,22 @@ class BaseModel(LRUCacheMixin, ABC):
             The `features` and `ignore_features` arguments are mutually exclusive. If both are specified, a
             `ValueError` is raised.
 
+        Warning:
+            The `memoized_dataset_cache_size` parameter is experimental and should be used with caution. It refers to
+            the number of datasets to keep in memory for speeding up repeated training. This can be useful when
+            hyperparameter tuning or cross-validation is performed, as the dataset does not need to be loaded from disk
+            every time. However, this can lead to memory issues if the dataset is too large. Specify 0 to disable the
+            cache. When finished with the fitting and transforming, please call the `_clear_dataset_cache` method to
+            clear the cache and free up memory.
+
         Args:
             features: List of feature names to be used by the model. If None, the default is all features
                 applicable to the model.
             ignore_features: List of feature names to be ignored by the model. If None, the default is to
                 ignore no features.
+            memoized_dataset_cache_size: The number of datasets to keep in memory for speeding up repeated training.
+                When finished with the fitting and transforming, please call the `_clear_dataset_cache` method to clear
+                the cache and free up memory. Specify 0 to disable the cache.
             cache_directory: Directory where the cache will be stored locally.
             cache_size: The maximum number of entries to keep in the cache.
 
@@ -66,6 +81,8 @@ class BaseModel(LRUCacheMixin, ABC):
             ValueError: If both `features` and `ignore_features` are specified.
         """
         super().__init__(cache_directory, cache_size)
+        self._memoized_dataset_cache_size = memoized_dataset_cache_size
+
         if features is not None and ignore_features is not None:
             msg = "Both `features` and `ignore_features` have been specified. The arguments are mutually exclusive."
             logger.error(msg)
@@ -75,6 +92,24 @@ class BaseModel(LRUCacheMixin, ABC):
         self._hyperparameters: HyperparametersType = {}
         self._features: tuple[str, ...] | None = tuple(features) if features is not None else None
         self._ignore_features: tuple[str, ...] = tuple(ignore_features) if ignore_features is not None else tuple()
+
+        self._memoized_load_dataset = lru_cache(maxsize=self._memoized_dataset_cache_size)(self._memoized_load_dataset)
+        """Load the dataset into memory and memoize the result.
+
+        Warning:
+            This method should be used with caution, as it loads the entire dataset into memory as a pandas DataFrame.
+            The returned DataFrame will be memoized using the `functools.lru_cache` to avoid reloading the
+            dataset multiple times. The cache size is set to the `memoized_dataset_cache_size` attribute.
+
+        Args:
+            data_schema: The data schema of the dataframe.
+            dataframe: The dataframe to load, wrapped in a `HashableVaexDataFrame` object.
+            additional_features: Additional features to load, such as the target feature.
+            name: Name of the dataset to be used in the log message.
+
+        Returns:
+            A pandas DataFrame with the loaded data.
+        """
 
     def fit(
         self,
@@ -306,6 +341,48 @@ class BaseModel(LRUCacheMixin, ABC):
             if self._features is None
             else self._features
         )
+
+    def _load_dataset(
+        self,
+        data_schema: DataSchema,
+        dataframe: vaex.DataFrame,
+        additional_features: list[str] | None = None,
+    ) -> pd.DataFrame:
+        """Load the dataset into memory.
+
+        Warning:
+            This method should be used with caution, as it loads the entire dataset into memory as a pandas DataFrame.
+
+        Args:
+            data_schema: The data schema of the dataframe.
+            dataframe: The dataframe to load.
+            additional_features: Additional features to load, such as the target feature.
+
+        Returns:
+            A pandas DataFrame with the loaded data.
+        """
+        feature_names = self._feature_set(data_schema)
+        df = get_columns(dataframe, feature_names + (additional_features if additional_features else [])).to_pandas_df()
+        return df  # type: ignore
+
+    def _memoized_load_dataset(
+        self,
+        data_schema: DataSchema,
+        dataframe: HashableVaexDataFrame,
+        additional_features: tuple[str, ...] | None = None,
+        name: str | None = None,
+    ) -> pd.DataFrame:
+        if name is not None:
+            name = f"{name.strip()} "
+        else:
+            name = ""
+
+        logger.info(f"Loading the {name}dataset into memory.")
+        return self._load_dataset(data_schema, dataframe.df, list(additional_features) if additional_features else None)
+
+    def clear_load_dataset_cache(self) -> None:
+        """Clears the cache for the `_memoized_load_dataset` method."""
+        self._memoized_load_dataset.cache_clear()
 
     @abstractmethod
     def _fit(

--- a/mleko/utils/vaex_helpers.py
+++ b/mleko/utils/vaex_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import vaex
 
 
@@ -88,3 +90,29 @@ def get_indices(df: vaex.DataFrame, indices: list[int]) -> vaex.DataFrame:
     selection = get_filtered_df(df, index.isin(indices))
     selection.delete_virtual_column(idx_name)
     return selection.extract()
+
+
+@dataclass(frozen=True)
+class HashableVaexDataFrame:
+    """An immutable hashable wrapper around a `vaex.DataFrame`."""
+
+    df: vaex.DataFrame
+
+    def __eq__(self, other) -> bool:
+        """Check if two `HashableVaexDataFrame` objects are equal.
+
+        Args:
+            other: `HashableVaexDataFrame` object to compare with.
+
+        Returns:
+            True if the two `HashableVaexDataFrame` objects are equal, False otherwise.
+        """
+        return isinstance(other, HashableVaexDataFrame) and self.df.fingerprint() == other.df.fingerprint()
+
+    def __hash__(self) -> int:
+        """Get the hash of the `HashableVaexDataFrame`.
+
+        Returns:
+            Hash of the `HashableVaexDataFrame`.
+        """
+        return hash(self.df.fingerprint())

--- a/tests/dataset/test_data_schema.py
+++ b/tests/dataset/test_data_schema.py
@@ -141,3 +141,47 @@ class TestDataSchema:
 
         with pytest.raises(ValueError):
             data_schema.get_type("non_existent_feature")
+
+    def test_hash_match(self):
+        """Should return the same hash for the same schema."""
+        data_schema1 = DataSchema(
+            numerical=["numerical1", "numerical2"],
+            categorical=["categorical1", "categorical2"],
+            boolean=["boolean1", "boolean2"],
+            datetime=["datetime1", "datetime2"],
+            timedelta=["timedelta1", "timedelta2"],
+        )
+        data_schema2 = DataSchema(
+            numerical=["numerical1", "numerical2"],
+            categorical=["categorical1", "categorical2"],
+            boolean=["boolean1", "boolean2"],
+            datetime=["datetime1", "datetime2"],
+            timedelta=["timedelta1", "timedelta2"],
+        )
+        assert hash(data_schema1) == hash(data_schema2)
+
+    def test_data_schema_equality_and_inequality(self):
+        """Should test equality and inequality of DataSchema instances."""
+        data_schema1 = DataSchema(
+            numerical=["numerical1", "numerical2"],
+            categorical=["categorical1", "categorical2"],
+            boolean=["boolean1", "boolean2"],
+            datetime=["datetime1", "datetime2"],
+            timedelta=["timedelta1", "timedelta2"],
+        )
+        data_schema2 = DataSchema(
+            numerical=["numerical1", "numerical2"],
+            categorical=["categorical1", "categorical2"],
+            boolean=["boolean1", "boolean2"],
+            datetime=["datetime1", "datetime2"],
+            timedelta=["timedelta1", "timedelta2"],
+        )
+        data_schema3 = DataSchema(
+            numerical=["numerical1", "numerical2"],
+            categorical=["categorical1", "categorical2"],
+            boolean=["boolean1", "boolean2"],
+            datetime=["datetime1", "datetime2"],
+            timedelta=["timedelta1"],
+        )
+        assert data_schema1 == data_schema2
+        assert data_schema1 != data_schema3

--- a/tests/model/test_base_model.py
+++ b/tests/model/test_base_model.py
@@ -56,7 +56,7 @@ class TestBaseModel:
         self, temporary_directory: Path, example_vaex_dataframe: vaex.DataFrame, example_data_schema: DataSchema
     ):
         """Should fit and transform dataframe."""
-        test_derived_model = self.DerivedModel(None, None, temporary_directory, 1)
+        test_derived_model = self.DerivedModel(None, None, 0, temporary_directory, 1)
 
         model, _ = test_derived_model.fit(example_data_schema, example_vaex_dataframe, example_vaex_dataframe, {})
         df = test_derived_model.transform(example_data_schema, example_vaex_dataframe)
@@ -76,7 +76,7 @@ class TestBaseModel:
         self, temporary_directory: Path, example_vaex_dataframe: vaex.DataFrame, example_data_schema: DataSchema
     ):
         """Should return vaex dataframe from feature_select method."""
-        test_derived_model = self.DerivedModel(None, None, temporary_directory, 1)
+        test_derived_model = self.DerivedModel(None, None, 0, temporary_directory, 1)
 
         model, _, df, _ = test_derived_model.fit_transform(
             example_data_schema, example_vaex_dataframe, example_vaex_dataframe, {}
@@ -89,7 +89,7 @@ class TestBaseModel:
         self, temporary_directory: Path, example_vaex_dataframe: vaex.DataFrame, example_data_schema: DataSchema
     ):
         """Should raise error when transform is called before fit."""
-        test_derived_model = self.DerivedModel(None, None, temporary_directory, 1)
+        test_derived_model = self.DerivedModel(None, None, 0, temporary_directory, 1)
 
         with pytest.raises(RuntimeError):
             test_derived_model.transform(example_data_schema, example_vaex_dataframe)
@@ -97,4 +97,4 @@ class TestBaseModel:
     def test_error_on_mutually_exclusive_arguments(self, temporary_directory: Path):
         """Should raise error when both `features` and `ignore_features` are passed."""
         with pytest.raises(ValueError):
-            self.DerivedModel([], [], temporary_directory, 1)
+            self.DerivedModel([], [], 0, temporary_directory, 1)

--- a/tests/utils/test_vaex_helpers.py
+++ b/tests/utils/test_vaex_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 import vaex
 
-from mleko.utils.vaex_helpers import get_column, get_columns, get_filtered_df, get_indices
+from mleko.utils.vaex_helpers import HashableVaexDataFrame, get_column, get_columns, get_filtered_df, get_indices
 
 
 @pytest.fixture(scope="module")
@@ -87,3 +87,22 @@ class TestGetIndices:
         assert result["column1"].tolist() == []  # type: ignore
         assert result["column2"].tolist() == []  # type: ignore
         assert result["column3"].tolist() == []  # type: ignore
+
+
+class TestHashableVaexDataFrame:
+    """Test suite for `utils.vaex_helpers.HashableVaexDataFrame`."""
+
+    def test_hashable_vaex_dataframe(self, example_vaex_dataframe: vaex.DataFrame):
+        """Identical DataFrames should have the same hash and be equal."""
+        hashable_df1 = HashableVaexDataFrame(example_vaex_dataframe)
+        hashable_df2 = HashableVaexDataFrame(example_vaex_dataframe)
+        assert hashable_df1 == hashable_df2
+        assert hash(hashable_df1) == hash(hashable_df2)
+
+    def test_inequality(self):
+        """Different DataFrames should have different hashes and not be equal."""
+        df1 = vaex.from_arrays(column1=[1, 2, 3], column2=[4, 5, 6], column3=[7, 8, 9])
+        df2 = vaex.from_arrays(column1=[1, 2, 3], column2=[4, 5, 6], column3=[7, 8, 10])
+        hashable_df1 = HashableVaexDataFrame(df1)
+        hashable_df2 = HashableVaexDataFrame(df2)
+        assert hashable_df1 != hashable_df2


### PR DESCRIPTION
By specifying the optional parameter `memoized_dataset_cache_size > 0`, the corresponding number of datasets will be kept in memory to avoid repeated conversion from `vaex` to `pandas` in settings where we perform repeated fitting using the same datasets e.g. hyperparamter tuning. Use with caution and always call `clear_load_dataset_cache` once completed to clear the cache.
